### PR TITLE
Update GA snippet to GA4

### DIFF
--- a/index.html
+++ b/index.html
@@ -2825,13 +2825,13 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jets/0.8.0/jets.min.js"></script>
   <script src="js/jquery.highlight.js"></script>
   <script src="js/main.js"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
   <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-    ga('create', 'UA-66576837-1', 'auto');
-    ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-XXXXXXXXXX');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace legacy Google Analytics snippet with GA4 configuration

## Testing
- `grep -n UA-66576837-1 -R`

------
https://chatgpt.com/codex/tasks/task_e_6846108607048321aaf8b731116c2b49