### PR TITLE
Add web app manifest and cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="img/favicon.ico?">
   <link rel="apple-touch-icon-precomposed" href="img/favicon-152.png">
   <link rel="mask-icon" href="img/pinned-tab-icon.svg" color="#000000">
+  <link rel="manifest" href="manifest.json">
   <meta name="description" content="Cheat sheet for Dark Souls 3. Checklist of things to do, items to get etc.">
   <meta name="author" content="Zachary Kjellberg">
   <meta name="mobile-web-app-capable" content="yes">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "Dark Souls 3 Cheat Sheet",
+  "short_name": "DS3 Cheats",
+  "start_url": ".",
+  "icons": [
+    {
+      "src": "img/favicon-152.png",
+      "sizes": "152x152",
+      "type": "image/png"
+    },
+    {
+      "src": "img/favicon.ico",
+      "sizes": "48x48 32x32 16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "img/pinned-tab-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,8 @@ const urlsToCache = [
   './css/main.css',
   './img/favicon.ico',
   './img/favicon-152.png',
-  './img/pinned-tab-icon.svg'
+  './img/pinned-tab-icon.svg',
+  './manifest.json',
 ];
 self.addEventListener('install', event => {
   event.waitUntil(


### PR DESCRIPTION
## Summary
- create web app manifest with icons and start URL
- load manifest in `index.html`
- cache manifest via service worker

## Testing
- `grep -n manifest index.html`
- `grep -n manifest sw.js`

------
https://chatgpt.com/codex/tasks/task_e_68461550b1108321ae5c3408e275f8fc