### PR TITLE
Add cache cleanup on SW activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ python -m http.server
 ### Offline Availability
 
 The checklist registers a service worker so that once the page has been loaded,
-its assets are cached for offline use. If updates to the site don't appear after
-reloading, clear your browser data to force the service worker to fetch the
-latest files.
+its assets are cached for offline use. When the service worker updates, caches
+from older versions are removed so the newest deployment replaces outdated
+files. If updates to the site don't appear after reloading, clear your browser
+data to force the service worker to fetch the latest files.
 
 ## Contribution Guide
 

--- a/sw.js
+++ b/sw.js
@@ -16,6 +16,17 @@ self.addEventListener('install', event => {
     caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
   );
 });
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(cacheNames =>
+      Promise.all(
+        cacheNames
+          .filter(name => name !== CACHE_NAME)
+          .map(name => caches.delete(name))
+      )
+    )
+  );
+});
 self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request).then(response => response || fetch(event.request))


### PR DESCRIPTION
## Summary
- delete old caches during service worker activate
- mention automatic cache cleanup in offline usage docs

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6846191a9c1883218e511e0ac19af41a