### PR TITLE
Fix GameFAQs link protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -2707,7 +2707,7 @@
       <div class="tab-pane" id="tabFAQ">      
         <h2>FAQ</h2>
 
-        <p>The foundation of this guide was based on <a href="https://github.com/smcnabb">Stephen McNabb</a>'s <a href="https://github.com/smcnabb/dark-souls-2-cheat-sheet">Dark Soul 2 Cheat Sheet</a> source code and <a href="http://www.gamefaqs.com/boards/168566-dark-souls-iii/73599466">DeathGodGarra's NPC Side Quests Guide V2</a> walkthrough guide</p>
+        <p>The foundation of this guide was based on <a href="https://github.com/smcnabb">Stephen McNabb</a>'s <a href="https://github.com/smcnabb/dark-souls-2-cheat-sheet">Dark Soul 2 Cheat Sheet</a> source code and <a href="https://www.gamefaqs.com/boards/168566-dark-souls-iii/73599466">DeathGodGarra's NPC Side Quests Guide V2</a> walkthrough guide</p>
         <p>This guide has evolved thanks to the many <a href="https://github.com/ZKjellberg/dark-souls-3-cheat-sheet/graphs/contributors">GitHub contributors</a> with many great suggestions, fixes and improvements!</p>
 
         <h3>I have feedback, how can I contribute?</h3>


### PR DESCRIPTION
## Summary
- use HTTPS link for DeathGodGarra's NPC Side Quests Guide in the FAQ section

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846262bf3208321abb0223a41b7b6f1