### PR TITLE
Use navigator clipboard with fallback

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -205,9 +205,17 @@ var profilesKey = 'darksouls3_profiles';
         *  Import & Export using textarea instead of files
         */
         $('#profileExportText').click(function(){
-            document.getElementById("profileText").value = JSON.stringify(profiles);
-            document.getElementById("profileText").select();
-            document.execCommand("copy");
+            var textArea = document.getElementById("profileText");
+            textArea.value = JSON.stringify(profiles);
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(textArea.value).catch(function(){
+                    textArea.select();
+                    document.execCommand("copy");
+                });
+            } else {
+                textArea.select();
+                document.execCommand("copy");
+            }
         });
 
         $('#profileImportText').click(function(){


### PR DESCRIPTION
## Summary
- improve copy-to-clipboard functionality using `navigator.clipboard`
- fall back to `document.execCommand` when the Clipboard API isn't available

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846264864348321bd4d2af0e1019c20