### PR TITLE
Update service worker lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python -m http.server
 ### Offline Availability
 
 The checklist registers a service worker so that once the page has been loaded,
-its assets are cached for offline use. When the service worker updates, caches
+its assets are cached for offline use. The service worker calls `self.skipWaiting()` when installing and `clients.claim()` when activated so updates become active without a refresh. When the service worker updates, caches
 from older versions are removed so the newest deployment replaces outdated
 files. If updates to the site don't appear after reloading, clear your browser
 data to force the service worker to fetch the latest files.

--- a/sw.js
+++ b/sw.js
@@ -28,6 +28,7 @@ const urlsToCache = [
   'https://maxcdn.bootstrapcdn.com/bootswatch/3.4.1/yeti/bootstrap.min.css'
 ];
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
   );
@@ -40,7 +41,7 @@ self.addEventListener('activate', event => {
           .filter(name => name !== CACHE_NAME)
           .map(name => caches.delete(name))
       )
-    )
+    ).then(() => self.clients.claim())
   );
 });
 self.addEventListener('fetch', event => {


### PR DESCRIPTION
## Summary
- refresh service worker immediately on install
- claim clients when activated
- document service worker lifecycle in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846308ba5f883218bcba172cabd5b4b