### PR TITLE
Add defer to local scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2830,12 +2830,12 @@
 
   <a class="btn btn-default btn-sm fadingbutton back-to-top" href="#top" role="button" aria-label="Back to Top">Back to Top&thinsp;<span aria-hidden="true" class="glyphicon glyphicon-arrow-up"></span></a>
 
-  <script src="js/jquery.min.js"></script>
-  <script src="js/jstorage.min.js"></script>
+  <script src="js/jquery.min.js" defer></script>
+  <script src="js/jstorage.min.js" defer></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jets/0.15.0/jets.min.js"></script>
-  <script src="js/jquery.highlight.js"></script>
-  <script src="js/main.js"></script>
+  <script src="js/jquery.highlight.js" defer></script>
+  <script src="js/main.js" defer></script>
   <script>
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('sw.js');


### PR DESCRIPTION
## Summary
- defer loading for local scripts in `index.html`

## Testing
- `node - <<'EOF'
const {JSDOM, ResourceLoader} = require('jsdom');
const fs = require('fs');
const path = require('path');
class LR extends ResourceLoader { fetch(url){ if(url.startsWith('http://localhost/')) return Promise.resolve(fs.readFileSync(path.join(__dirname,url.replace('http://localhost/','')))); return Promise.resolve(Buffer.from('')); } }
(async()=>{ const dom = await JSDOM.fromFile('index.html',{runScripts:'dangerously',resources:new LR(),pretendToBeVisual:true,url:'http://localhost/index.html',beforeParse(w){w.localStorage={setItem(){},getItem(){return null}};w.navigator.serviceWorker={register:(p)=>console.log('sw registered',p)};w.Jets=function(){}}}); dom.window.addEventListener('load',()=>{console.log('loaded');dom.window.close();}); })();
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68463098313883218049c2d2d71016c9