### PR TITLE
Fix plugin URL typo

### DIFF
--- a/js/jquery.highlight.js
+++ b/js/jquery.highlight.js
@@ -2,7 +2,7 @@
  * jQuery Highlight plugin
  *
  * Based on highlight v3 by Johann Burkard
- * http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html
+ * http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-highlighting-jquery-plugin.html
  *
  * Code a little bit refactored and cleaned (in my humble opinion).
  * Most important changes:


### PR DESCRIPTION
## Summary
- correct a typo in the jQuery Highlight plugin comment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684633c23b888321979acdda4dadfe6a