### PR TITLE
Improve service worker robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ from older versions are removed so the newest deployment replaces outdated
 files. If updates to the site don't appear after reloading, clear your browser
 data to force the service worker to fetch the latest files.
 
+External CDN assets (e.g. Bootstrap stylesheets and the Jets search library) are
+cached when available. If these requests fail the service worker still installs,
+but those files won't be available offline. Hosting these libraries locally will
+ensure they work without a network connection.
+
 ### Installing the App
 
 In browsers that support Progressive Web Apps (PWAs) you can install this

--- a/sw.js
+++ b/sw.js
@@ -30,7 +30,15 @@ const urlsToCache = [
 self.addEventListener('install', event => {
   self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+    caches.open(CACHE_NAME).then(cache => {
+      return Promise.all(
+        urlsToCache.map(url =>
+          cache.add(url).catch(err => {
+            console.warn('Cache add failed for', url, err);
+          })
+        )
+      );
+    })
   );
 });
 self.addEventListener('activate', event => {


### PR DESCRIPTION
## Summary
- gracefully cache URLs in sw.js
- document CDN caching behavior

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684633d151008321b506e56ef75f0d20