### PR TITLE
Add SRI hashes for CDN resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ cached when available. If these requests fail the service worker still installs,
 but those files won't be available offline. Hosting these libraries locally will
 ensure they work without a network connection.
 
+### Updating CDN Integrity Hashes
+
+Link and script tags for third‑party libraries include [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hashes.
+If you update these dependencies, generate new hashes with:
+
+```bash
+curl -Ls <url> | openssl dgst -sha384 -binary | base64 -w0
+```
+
+Place the resulting value in the `integrity` attribute of the corresponding tag in `index.html` and keep `crossorigin="anonymous"`.
+
 ### Installing the App
 
 In browsers that support Progressive Web Apps (PWAs) you can install this

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <meta name="mobile-web-app-capable" content="yes">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#000000">
-  <link id="bootstrap" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+  <link id="bootstrap" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
   <link href="css/main.css" rel="stylesheet">
   <meta property="og:title" content="Dark Souls 3 Cheat Sheet">
   <meta property="og:description" content="Cheat sheet for Dark Souls 3. Checklist of things to do, items to get etc.">
@@ -2832,8 +2832,8 @@
 
   <script src="js/jquery.min.js" defer></script>
   <script src="js/jstorage.min.js" defer></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jets/0.15.0/jets.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jets/0.15.0/jets.min.js" integrity="sha384-8Trrt/O4q0xLdS8EBX7CEbNcpchKJeWbOznbIURCaucngR34jq2mTFWORXidssYv" crossorigin="anonymous"></script>
   <script src="js/jquery.highlight.js" defer></script>
   <script src="js/main.js" defer></script>
   <script>


### PR DESCRIPTION
## Summary
- compute SRI hashes for Bootstrap and Jets assets
- add integrity and crossorigin attributes in `index.html`
- document how to update hashes when CDN files change in `README.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68463835252c8321b9136719706179ef