### PR TITLE
Fix offline fallback for service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -54,6 +54,9 @@ self.addEventListener('activate', event => {
 });
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches.match(event.request).then(cacheRes =>
+      cacheRes ||
+        fetch(event.request).catch(() => caches.match('./index.html'))
+    )
   );
 });


### PR DESCRIPTION
## Summary
- update `fetch` event to serve cached `index.html` if network fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68463b6e58208321b6c4463af69fbd52