### PR TITLE
Add ESLint script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ that must be replaced with your Measurement ID:
 Replace `G-XXXXXXXXXX` with your own tracking ID before deploying.
 Contributors should replace the placeholder with their own ID or remove the snippet entirely if tracking is not desired.
 
+## Linting
+
+Run ESLint to check JavaScript source files for issues:
+
+```bash
+npm run lint
+```
+
+This will lint `js/main.js`, `js/jquery.highlight.js`, and `sw.js`.
+
 ## Contribution Guide
 
 If you are interested in contributing to this guide, I welcome Pull Requests.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "To view the cheat sheet [click here](https://vesylum.github.io/dark-souls-3-cheat-sheet/).",
   "main": "sw.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint js/main.js js/jquery.highlight.js sw.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add an npm `lint` script for ESLint
- document how to run the linter

## Testing
- `npm run lint`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68463b79aab08321b33c76caaad97292