### PR TITLE
Add GitHub Actions lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run lint


### PR DESCRIPTION
## Summary
- add Node.js GitHub Actions workflow to run `npm run lint` on pushes and PRs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846496428e0832196e826d22bc472af