### PR TITLE
Add data-id duplication check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "To view the cheat sheet [click here](https://vesylum.github.io/dark-souls-3-cheat-sheet/).",
   "main": "sw.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node scripts/check-data-ids.js",
     "start": "http-server -p 8000",
     "lint": "eslint js/main.js"
   },

--- a/scripts/check-data-ids.js
+++ b/scripts/check-data-ids.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '..', 'index.html');
+const html = fs.readFileSync(filePath, 'utf8');
+
+const regex = /data-id\s*=\s*"([^"]+)"/g;
+const ids = [];
+let match;
+
+while ((match = regex.exec(html)) !== null) {
+  ids.push(match[1]);
+}
+
+const seen = new Set();
+const duplicates = new Set();
+
+for (const id of ids) {
+  if (seen.has(id)) {
+    duplicates.add(id);
+  } else {
+    seen.add(id);
+  }
+}
+
+if (duplicates.size > 0) {
+  const dupList = Array.from(duplicates).join(', ');
+  throw new Error(`Duplicate data-id values found: ${dupList}`);
+}
+
+console.log(`Checked ${ids.length} data-id attributes, no duplicates found.`);


### PR DESCRIPTION
## Summary
- add `scripts/check-data-ids.js` to scan index.html for duplicate `data-id`s
- expose check via `npm test` in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68464968a45083219ae50f7bf59a353c