### PR TITLE
Add favicon-512 to service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ds3-checklist-v4';
+const CACHE_NAME = 'ds3-checklist-v5';
 const urlsToCache = [
   './',
   './index.html',
@@ -9,6 +9,7 @@ const urlsToCache = [
   './manifest.json',
   './img/favicon.ico',
   './img/favicon-152.png',
+  './img/favicon-512.png',
   './img/pinned-tab-icon.svg',
   './js/jstorage.min.js',
   './vendor/bootstrap/bootstrap.min.css',


### PR DESCRIPTION
## Summary
- cache the new 512x512 favicon
- bump service worker cache version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68464ffc9aac8321aeeb02c71e3974b4