### PR TITLE
Remove unused favicon entry from service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -9,7 +9,6 @@ const urlsToCache = [
   './manifest.json',
   './img/favicon.ico',
   './img/favicon-152.png',
-  './img/favicon-512.png',
   './img/pinned-tab-icon.svg',
   './js/jstorage.min.js',
   './vendor/bootstrap/bootstrap.min.css',


### PR DESCRIPTION
## Summary
- drop `favicon-512.png` from the service worker cache list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684652c6af108321a26d8fb7917c9874