### PR TITLE
Fix reassignment of content variable in addCheckbox

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -499,7 +499,7 @@
     function addCheckbox(el) {
         const $el = $(el);
         // assuming all content lies on the first line
-        const content = $el.html().split('\n')[0];
+        let content = $el.html().split('\n')[0];
         const sublists = $el.children('ul');
 
         content =


### PR DESCRIPTION
## Summary
- ensure `addCheckbox` reassigns `content` by using `let`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684652cf7fbc83218f62cf842e890e1b