### PR TITLE
Add defer to local JS scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2832,8 +2832,8 @@
 
   <script src="js/jquery.min.js" defer></script>
   <script src="js/jstorage.min.js" defer></script>
-  <script src="vendor/bootstrap/bootstrap.min.js"></script>
-  <script src="vendor/jets.min.js"></script>
+  <script src="vendor/bootstrap/bootstrap.min.js" defer></script>
+  <script src="vendor/jets.min.js" defer></script>
   <script src="js/jquery.highlight.js" defer></script>
   <script src="js/main.js" defer></script>
   <script>


### PR DESCRIPTION
## Summary
- load bootstrap and jets scripts with `defer` so they don't block rendering

## Testing
- `npm run lint`
- `npm test`
- `node test-boot-jets.js` *(verifies Jets and Bootstrap load)*

------
https://chatgpt.com/codex/tasks/task_e_68465992777083219289539a8e3afe79