### PR TITLE
Fix theme validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ npm start
 ```
 `npm test` checks that no duplicate `data-id` values appear in `index.html`.
 
+### Themes
+
+Your chosen theme is saved in the browser. If an unknown value is found it
+defaults back to the **Standard** style and the invalid entry is removed.
+
 ### Offline Availability
 
 The checklist registers a service worker so that once the page has been loaded,

--- a/js/main.js
+++ b/js/main.js
@@ -386,9 +386,18 @@
 
     // Setup ("bootstrap", haha) styling
     function themeSetup(stylesheet) {
-        if(stylesheet === null || stylesheet === undefined) { // if we didn't get a param, then
-            stylesheet = $.jStorage.get("style") || "Standard"; // fall back on "Standard" if no value is stored
+        if (stylesheet === null || stylesheet === undefined) {
+            // If no argument was provided, try the stored preference
+            stylesheet = $.jStorage.get("style");
         }
+
+        // Validate the theme exists; fall back to "Standard" if it does not
+        if (!themes[stylesheet]) {
+            // Remove invalid value from storage so later calls don't reuse it
+            $.jStorage.deleteKey("style");
+            stylesheet = "Standard";
+        }
+
         $("#bootstrap").attr("href", themes[stylesheet]);
     }
 


### PR DESCRIPTION
## Summary
- validate stored theme entry before applying
- note theme reset behaviour in the docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846599ae5508321bca0c266d79e66f4