### PR TITLE
Improve aria-current handling for nav tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse" id="nav-collapse">
         <ul class="nav navbar-nav">
-          <li class="active"><a href="#tabPlaythrough" data-toggle="tab" data-target="#tabPlaythrough,#btnHideCompleted">Playthrough</a></li>
+          <li class="active"><a href="#tabPlaythrough" data-toggle="tab" data-target="#tabPlaythrough,#btnHideCompleted" aria-current="page">Playthrough</a></li>
           <li><a href="#tabChecklists" data-toggle="tab" data-target="#tabChecklists,#btnHideCompleted">Achievements</a></li>
           <li><a href="#tabWeaponsShields" data-toggle="tab" data-target="#tabWeaponsShields,#btnHideCompleted">Weapons/Shields</a></li>
           <li><a href="#tabArmors" data-toggle="tab" data-target="#tabArmors,#btnHideCompleted">Armor</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -682,6 +682,9 @@
         $('.nav.navbar-nav li a').on('click', function(el) {
             profiles[profilesKey][profiles.current].current_tab = $(this).attr('href');
 
+            $('.nav.navbar-nav li a[aria-current="page"]').removeAttr('aria-current');
+            $(this).attr('aria-current', 'page');
+
             $.jStorage.set(profilesKey, profiles);
         });
      });


### PR DESCRIPTION
## Summary
- mark initial Playthrough tab link with `aria-current="page"`
- update tab switching script to manage `aria-current` properly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68465dfa5360832189f11ab1dddbfe8e