### PR TITLE
Fix profile export update timing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -511,9 +511,9 @@
                 this.innerHTML = overallChecked + '/' + overallCount;
                 $(this).removeClass('done').addClass('in_progress');
             }
+        });
         // Update textarea for profile export
         document.getElementById("profileText").value = JSON.stringify(profiles);
-        });
     }
 
     function addCheckbox(el) {


### PR DESCRIPTION
## Summary
- ensure profile export textarea is updated once per totals calculation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684663d6204883218bbffeb5dbcbbd57