### PR TITLE
Add docs and CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,29 @@
+name: Node CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run lint
+      - run: npm test
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/gh-pages'
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/gh-pages'
+        uses: actions/deploy-pages@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2025-06-09
+- Initial release.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct.
+
+## Our Pledge
+
+We pledge to make participation in our project a harassment-free experience for everyone.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue on GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thank you for considering contributing to this project!
+
+## Getting started
+
+1. Ensure [Node.js](https://nodejs.org/) 20 or later is installed.
+2. Run `npm install` to install dependencies.
+3. Use `npm run lint` and `npm test` to verify your changes.
+4. Run `npm start` to serve the site locally on <http://localhost:8000>.
+
+Pull requests are welcome. Please keep `index.html` in sync with `index.template.html` and avoid duplicate `data-id` values by running `npm test`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+If you discover a security vulnerability, please open a private issue on GitHub or contact the maintainers.
+
+We ask that you do not disclose vulnerabilities publicly until we have had a chance to address them.


### PR DESCRIPTION
## Summary
- add CODE_OF_CONDUCT, CONTRIBUTING, SECURITY
- add CHANGELOG
- add Node CI workflow that runs lint & test on Node 20 and deploys gh-pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684708f634048321a8a9a8a4ac80640a