### PR TITLE
Limit service worker fetch scope

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ds3-checklist-v6';
+const CACHE_NAME = 'ds3-checklist-v7';
 const urlsToCache = [
   './',
   '/',
@@ -57,6 +57,10 @@ self.addEventListener('activate', event => {
   );
 });
 self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET' ||
+      new URL(event.request.url).origin !== self.location.origin) {
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(cacheRes =>
       cacheRes ||


### PR DESCRIPTION
## Summary
- only handle same-origin GET requests in `sw.js`
- bump `CACHE_NAME` to `ds3-checklist-v7`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68470e99d7d48321ba1ea9f2697f3716