### PR TITLE
Automate cache refresh on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ npm start
 ### Building `index.html`
 
 Run `npm run build` to regenerate `index.html` from
-`index.template.html` and `data/playthrough.json`. Rebuild whenever the
-template or playthrough data changes.
+`index.template.html` and `data/playthrough.json`. The build script also
+updates the service worker's cache name using the project version and a
+timestamp so browsers fetch the latest assets. Rebuild whenever the
+template or playthrough data changes or cached files are updated.
 
 ### Themes
 
@@ -53,8 +55,9 @@ files. If updates to the site don't appear after reloading, clear your browser
 data to force the service worker to fetch the latest files.
 
 Whenever you modify the `urlsToCache` list—or any of the files it references—
-increment the `CACHE_NAME` constant in `sw.js`. This forces browsers to refresh
-their caches with the updated assets so visitors aren't served stale files.
+run `npm run build`. This updates the `CACHE_NAME` constant in `sw.js`
+automatically so browsers refresh their caches with the updated assets and
+aren't served stale files.
 
 Bootstrap and the Jets search library are provided locally in the `vendor`
 directory and cached by the service worker along with the rest of the site's

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "http-server -p 8000",
     "lint": "eslint js/main.js",
     "prepare": "husky install",
-    "build": "node scripts/build-playthrough.js",
+    "build": "node scripts/update-cache-name.js && node scripts/build-playthrough.js",
     "extract": "node scripts/extract-playthrough.js"
   },
   "keywords": [],

--- a/scripts/update-cache-name.js
+++ b/scripts/update-cache-name.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const pkg = require('../package.json');
+
+const swPath = path.join(__dirname, '..', 'sw.js');
+let sw = fs.readFileSync(swPath, 'utf8');
+
+const version = pkg.version || '0.0.0';
+const timestamp = Date.now();
+const newName = `ds3-checklist-v${version}-${timestamp}`;
+
+const replaced = sw.replace(/const CACHE_NAME = '[^']+';/, `const CACHE_NAME = '${newName}';`);
+fs.writeFileSync(swPath, replaced);
+console.log('Updated CACHE_NAME to', newName);

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ds3-checklist-v6';
+const CACHE_NAME = 'ds3-checklist-v1.0.0-1749487360887';
 const urlsToCache = [
   './',
   '/',


### PR DESCRIPTION
## Summary
- auto-generate service worker `CACHE_NAME` during build
- hook new script into npm build command
- document automatic cache refresh in README

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68470ea2df6883218e87609da86a649c