### PR TITLE
Automate service worker cache refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ npm start
 
 Run `npm run build` to regenerate `index.html` from
 `index.template.html` and `data/playthrough.json`. Rebuild whenever the
-template or playthrough data changes.
+template or playthrough data changes. This command also updates the
+service worker's `CACHE_NAME` using the package version and a timestamp
+so browsers fetch the latest assets after each deployment.
 
 ### Themes
 
@@ -52,9 +54,10 @@ from older versions are removed so the newest deployment replaces outdated
 files. If updates to the site don't appear after reloading, clear your browser
 data to force the service worker to fetch the latest files.
 
-Whenever you modify the `urlsToCache` list—or any of the files it references—
-increment the `CACHE_NAME` constant in `sw.js`. This forces browsers to refresh
-their caches with the updated assets so visitors aren't served stale files.
+The build script automatically updates the `CACHE_NAME` constant in
+`sw.js` using the package version and a timestamp. This forces browsers to
+refresh their caches with the updated assets so visitors aren't served
+stale files.
 
 Bootstrap and the Jets search library are provided locally in the `vendor`
 directory and cached by the service worker along with the rest of the site's

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "http-server -p 8000",
     "lint": "eslint js/main.js",
     "prepare": "husky install",
-    "build": "node scripts/build-playthrough.js",
+    "build": "node scripts/update-cache-name.js && node scripts/build-playthrough.js",
     "extract": "node scripts/extract-playthrough.js"
   },
   "keywords": [],

--- a/scripts/update-cache-name.js
+++ b/scripts/update-cache-name.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkgPath = path.join(__dirname, '..', 'package.json');
+const swPath = path.join(__dirname, '..', 'sw.js');
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const version = pkg.version || '0.0.0';
+const stamp = Date.now();
+const newName = `ds3-checklist-v${version}-${stamp}`;
+
+let sw = fs.readFileSync(swPath, 'utf8');
+const regex = /const CACHE_NAME = '.*?';/;
+if (!regex.test(sw)) {
+  throw new Error('CACHE_NAME constant not found in sw.js');
+}
+sw = sw.replace(regex, `const CACHE_NAME = '${newName}';`);
+fs.writeFileSync(swPath, sw);
+console.log('Updated CACHE_NAME to', newName);


### PR DESCRIPTION
## Summary
- refresh CACHE_NAME during build using a new script
- call the script from `npm run build`
- document automatic cache updates in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684711a78cf48321bcf17726114fefdb